### PR TITLE
Handle rule attributes 14 and 15 from stardoc_output proto

### DIFF
--- a/components/Stardoc.tsx
+++ b/components/Stardoc.tsx
@@ -47,11 +47,9 @@ function attributeTypeDescription(attributeType: number): string {
       return 'label'
     case 'OUTPUT_LIST':
       return 'list of labels'
-    case 'UNKNOWN':
-    case 'UNRECOGNIZED':
-      throw new Error('unknown attribute type ' + attributeType)
   }
-  throw new Error('unknown attribute type ' + attributeType)
+  console.warn('Unknown stardoc_output proto attribute type:', attributeType)
+  return 'unknown'
 }
 
 // port of https://github.com/bazelbuild/bazel/blob/09c621e4cf5b968f4c6cdf905ab142d5961f9ddc/src/main/java/com/google/devtools/build/skydoc/rendering/MarkdownUtil.java#L191-L221


### PR DESCRIPTION
The buf proto for stardoc outputs is outdated and doesn't handle newer attribute types, including a attr.string_keyed_label_dict (https://bazel.build/rules/lib/toplevel/attr#string_keyed_label_dict). This change is a workaround to prevent the doc generation from failing, but isn't a permanent fix.

Closes https://github.com/bazel-contrib/bcr-ui/issues/207