### PR TITLE
chore: remove redundant h1

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -70,9 +70,6 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
           src="https://static.scarf.sh/a.png?x-pxid=d6abab51-c2a7-4705-8342-c648e04db0b4"
         />
         <div className="max-w-4xl w-4xl mx-auto mt-8 flex flex-col items-center">
-          <h1 className="text-bzl-green font-bold text-6xl">
-            Bazel Central Registry
-          </h1>
           <form onSubmit={handleSubmitSearch} className="contents">
             <input
               type="text"


### PR DESCRIPTION
Now that #199 added Bazel Central Registry in the header.

Saves some vertical space