### PR TITLE
Show number of modules, make footer sticky

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,9 +11,8 @@ export const Footer: React.FC<FooterProps> = () => {
   return (
     <footer className="flex flex-col bg-bzl-green-dark text-white items-center justify-center gap-2 h-18 p-4 bottom-2">
       <div className="text-center">
-        The Bazel Central Registry is maintained by the Bazel team and the
+        The Bazel Central Registry is maintained by the Bazel team and the{' '}
         <a href={SIG_LINK} className="underline hover:text-gray-200">
-          {' '}
           Bazel Rules authors SIG.
         </a>
       </div>

--- a/pages/all-modules.tsx
+++ b/pages/all-modules.tsx
@@ -26,7 +26,12 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
       <main className="m-4 l:m-0">
         <div className="max-w-4xl w-4xl mx-auto mt-8 flex flex-col items-center">
           <div>
-            <h2 className="font-bold text-lg">All modules</h2>
+            <h2 className="font-bold text-lg">
+              All modules
+              <span className="text-gray-600 font-normal ml-2">
+                ({searchIndex.length} total)
+              </span>
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
               {searchIndex.map(
                 ({

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -76,7 +76,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
               autoFocus
               id="search-navbar"
               className="my-6 h-12 block p-2 pl-10 w-full max-w-xl text-gray-900 bg-white rounded-lg border border-gray-300 sm:text-sm focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Search for module..."
+              placeholder={`Search ${searchIndex.length} modules...`}
               onChange={(e) => setSearchQueryInput(e.target.value)}
             />
           </form>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -59,9 +59,9 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
   }
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col min-h-screen">
       <Header />
-      <main className="m-4 l:m-0">
+      <main className="m-4 l:m-0 flex-1">
         <div className="max-w-4xl w-4xl mx-auto mt-8 flex flex-col items-center">
           <form onSubmit={handleSubmitSearch} className="contents">
             <input
@@ -75,7 +75,14 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
             />
           </form>
           <div className="w-full max-w-4xl">
-            <h2 className="font-bold text-lg">Search results</h2>
+            <h2 className="font-bold text-lg">
+              Search results
+              {getSearchQuery() && (
+                <span className="text-gray-600 font-normal ml-2">
+                  ({searchResults.length} {searchResults.length === 1 ? 'module' : 'modules'})
+                </span>
+              )}
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mt-4">
               {searchResults && searchResults.length ? (
                 searchResults.map(
@@ -108,7 +115,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                 <div className="text-gray-600">
                   <p>
                     No results for &quot;
-                    <span className="text-black">{router.query.q}</span>&quot;.
+                    <span className="text-black">{router.query.q}</span>&quot; (0 results).
                   </p>
                   <p>
                     You can{' '}

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -77,7 +77,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
           <div className="w-full max-w-4xl">
             <h2 className="font-bold text-lg">
               Search results
-              {getSearchQuery() && (
+              {getSearchQuery() && searchResults && (
                 <span className="text-gray-600 font-normal ml-2">
                   ({searchResults.length} {searchResults.length === 1 ? 'module' : 'modules'})
                 </span>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -115,7 +115,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                 <div className="text-gray-600">
                   <p>
                     No results for &quot;
-                    <span className="text-black">{router.query.q}</span>&quot; (0 results).
+                    <span className="text-black">{router.query.q}</span>&quot; (0 modules).
                   </p>
                   <p>
                     You can{' '}

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -79,7 +79,8 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
               Search results
               {getSearchQuery() && searchResults && (
                 <span className="text-gray-600 font-normal ml-2">
-                  ({searchResults.length} {searchResults.length === 1 ? 'module' : 'modules'})
+                  ({searchResults.length}{' '}
+                  {searchResults.length === 1 ? 'module' : 'modules'})
                 </span>
               )}
             </h2>
@@ -115,7 +116,8 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                 <div className="text-gray-600">
                   <p>
                     No results for &quot;
-                    <span className="text-black">{router.query.q}</span>&quot; (0 modules).
+                    <span className="text-black">{router.query.q}</span>&quot;
+                    (0 modules).
                   </p>
                   <p>
                     You can{' '}


### PR DESCRIPTION
## why?

https://github.com/bazel-contrib/bcr-ui/issues/217

## how

Show the total number of modules on homepage in search placeholder, on the browse page, and number of search results.

Also make the footer stick to the bottom when there aren't many search results.
