### PR TITLE
move boost.json route out of the way

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,17 @@ const nextConfig = {
   // Increase timeout for generating static pages from default 60s to avoid issues like:
   // Restarted static page generation for /modules/xxx/y.y.y because it took more than 60 seconds
   staticPageGenerationTimeout: 600,
+
+  exportPathMap: async function (defaultPathMap) {
+    const newMap = { ...defaultPathMap }
+    Object.keys(newMap).forEach((path) => {
+      if (path.includes('boost.json')) {
+        newMap[path.replace('boost.json', 'boost-json')] = newMap[path]
+        delete newMap[path]
+      }
+    })
+    return newMap
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
Next.js dynamic routes snapshot their static props into [route].json, and there is now a 'boost' module.

This changes the URL for https://registry.bazel.build/modules/boost.json which is NOT desirable, however based on my research we can't prevent next.js from writing a conflicting boost.json file for the new "boost" module.