### PR TITLE
fix: skip rendering boost for now

### DIFF
--- a/data/utils.ts
+++ b/data/utils.ts
@@ -281,6 +281,11 @@ const buildAllModuleInfoInner = async (): Promise<AllModuleInfo> => {
     ? process.env.MODULE_NAMES.split(',').map((name) => name.trim())
     : await listModuleNames()
   for (const moduleName of modulesNames) {
+    if (moduleName === 'boost') {
+      // Next.js would write the static props snapshot for a "modules/boost" dynamic route to "boost.json"
+      // but there is also a BCR module of that name. So skip build-time pre-rendering of the boost module.
+      continue
+    }
     const versions = await listModuleVersions(moduleName)
     for (const moduleVersion of versions) {
       const moduleInfo = await extractModuleInfo(moduleName, moduleVersion)


### PR DESCRIPTION
Unblocks rendering all other modules, due to conflict introduced by boost + boost.json modules

See also other attempts in #231 and #230 