### PR TITLE
Improve search results: search and display repo description, adjust fuse indexing

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -181,8 +181,8 @@
   "moduleExtensions": {
     "@@aspect_rules_js+//npm:extensions.bzl%pnpm": {
       "general": {
-        "bzlTransitiveDigest": "s7IQfaNfCfnElBtvyj3cfjthilDIi8nW+jdF5Ec7ukA=",
-        "usagesDigest": "N3XLfP9qJIfx37ulW3MtZjMt8oxSbakVJST9UAK3bGs=",
+        "bzlTransitiveDigest": "HJe9Y+rPWm2mgKPUuI3mG+wijbn/FZP/v9BrcoFYK7Q=",
+        "usagesDigest": "8m6CUWeR/dQZ8MdctQ+g+btjKkrApQiWZVg6ModFFZE=",
         "recordedFileInputs": {
           "@@//package.json": "d1aea803104b786108d8ed3ed1d53b4e6176efe0e6a35550be5096fd5021972c"
         },
@@ -360,7 +360,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "gA7tPEdJXhskzPIEUxjX9IdDrM6+WjfbgXJ8Ez47umk=",
-        "usagesDigest": "oB29pD38iR1cklGAlGORmclK9ZkJ4kiW5AHhz4bYIUk=",
+        "usagesDigest": "s2VatwD7YDWOEOHVso5JqpkdVAvE31VzFKyNfaORgsY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -369,7 +369,7 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "aspect_rules_js": "2.6.0",
+                "aspect_rules_js": "2.7.0",
                 "aspect_rules_ts": "3.7.0",
                 "aspect_tools_telemetry": "0.2.8"
               }
@@ -457,7 +457,7 @@
     "@@rules_nodejs+//nodejs:extensions.bzl%node": {
       "general": {
         "bzlTransitiveDigest": "SqbzUarOVzAfK28Ca5+NIU3LUwnW/b3h0xXBUS97oyI=",
-        "usagesDigest": "I5agJc8J0sj4FsuFUCobP39Ti5Sz1Hw/cgUjljIWS+U=",
+        "usagesDigest": "L7gFhOtnSY9/R+G6+HYkr9pKRPSOdG+a7C+OREsW0qU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/components/ModuleCard.tsx
+++ b/components/ModuleCard.tsx
@@ -13,6 +13,7 @@ export interface ModuleCardProps {
   isArchived?: boolean
   deprecated?: boolean
   deprecationMessage?: string | null
+  repoDescription?: string | null
 }
 
 export const ModuleCard: React.FC<ModuleCardProps> = ({
@@ -25,6 +26,7 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
   isArchived = false,
   deprecated = false,
   deprecationMessage,
+  repoDescription,
 }) => {
   const authorDateRel = authorDate
     ? formatDistance(parseISO(authorDate), new Date(), { addSuffix: true })
@@ -32,29 +34,42 @@ export const ModuleCard: React.FC<ModuleCardProps> = ({
 
   return (
     <Link href={`/modules/${module}`}>
-      <div className="w-full h-24 border rounded flex flex-col items-center justify-center shadow-sm hover:shadow-lg">
-        <div className="w-full p-4 flex justify-between">
-          <div>
-            <div className="font-bold">{module}</div>
-            <div className="flex items-center gap-2">
-              {version}
-              <Badges
-                hasAttestationFile={hasAttestationFile}
-                hasStardocs={hasStardocs}
-                hasFundingLinks={hasFundingLinks}
-                isArchived={isArchived}
-                deprecated={deprecated}
-                deprecationMessage={deprecationMessage}
-              />
+      <div className={`w-full border rounded flex flex-col shadow-sm hover:shadow-lg ${repoDescription ? 'min-h-[120px]' : 'h-24'}`}>
+        <div className="w-full p-4 flex justify-between flex-col">
+          <div className="flex justify-between items-start">
+            <div className="flex-1 min-w-0">
+              <div className="font-bold">{module}</div>
+              <div className="flex items-center gap-2">
+                {version}
+                <Badges
+                  hasAttestationFile={hasAttestationFile}
+                  hasStardocs={hasStardocs}
+                  hasFundingLinks={hasFundingLinks}
+                  isArchived={isArchived}
+                  deprecated={deprecated}
+                  deprecationMessage={deprecationMessage}
+                />
+              </div>
+            </div>
+            <div className="flex ml-4">
+              {authorDateRel && (
+                <div className="text-gray-500 self-start text-sm" suppressHydrationWarning>
+                  updated {authorDateRel}
+                </div>
+              )}
             </div>
           </div>
-          <div className="flex">
-            {authorDateRel && (
-              <div className="text-gray-500 self-end" suppressHydrationWarning>
-                updated {authorDateRel}
-              </div>
-            )}
-          </div>
+          {repoDescription && (
+            <div className="mt-2 text-sm text-gray-600 overflow-hidden">
+              <p className="overflow-hidden text-ellipsis" style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+              }}>
+                {repoDescription}
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </Link>

--- a/data/utils.ts
+++ b/data/utils.ts
@@ -61,6 +61,7 @@ export interface SearchIndexEntry {
   hasFundingLinks: boolean
   deprecated: boolean
   deprecationMessage: string | null
+  repoDescription: string | null
 }
 
 export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
@@ -92,6 +93,7 @@ export const buildSearchIndex = async (): Promise<SearchIndexEntry[]> => {
         isArchived: githubMetadata?.isArchived || false,
         deprecated: !!metadata.deprecated,
         deprecationMessage: metadata.deprecated || null,
+        repoDescription: githubMetadata?.description || null,
       }
     })
   )

--- a/pages/all-modules.tsx
+++ b/pages/all-modules.tsx
@@ -39,6 +39,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                   hasFundingLinks,
                   deprecated,
                   deprecationMessage,
+                  repoDescription,
                 }) => (
                   <ModuleCard
                     key={module}
@@ -52,6 +53,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                       hasFundingLinks,
                       deprecated,
                       deprecationMessage,
+                      repoDescription,
                     }}
                   />
                 )

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -94,6 +94,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
                     hasFundingLinks,
                     deprecated,
                     deprecationMessage,
+                    repoDescription,
                   }) => (
                     <ModuleCard
                       key={module}
@@ -106,6 +107,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
                         hasFundingLinks,
                         deprecated,
                         deprecationMessage,
+                        repoDescription,
                       }}
                     />
                   )
@@ -126,6 +128,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
                     hasFundingLinks,
                     deprecated,
                     deprecationMessage,
+                    repoDescription,
                   }) => (
                     <ModuleCard
                       key={module}
@@ -139,6 +142,7 @@ const Home: NextPage<HomePageProps> = ({ searchIndex }) => {
                         hasFundingLinks,
                         deprecated,
                         deprecationMessage,
+                        repoDescription,
                       }}
                     />
                   )

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -32,11 +32,12 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
   const [searchQueryInput, setSearchQueryInput] = useState<string>(
     getSearchQuery() || ''
   )
-
   const fuseIndex = new Fuse(searchIndex, {
     includeScore: true,
-    threshold: 0.4,
-    keys: ['module'],
+    threshold: 0.3,
+    keys: ['module','repoDescription'],
+    useExtendedSearch: true,
+    ignoreLocation: true,
   })
 
   useEffect(() => {
@@ -88,6 +89,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                     hasFundingLinks,
                     deprecated,
                     deprecationMessage,
+                    repoDescription,
                   }) => (
                     <ModuleCard
                       key={module}
@@ -100,6 +102,7 @@ const Search: NextPage<SearchPageProps> = ({ searchIndex }) => {
                         hasFundingLinks,
                         deprecated,
                         deprecationMessage,
+                        repoDescription,
                       }}
                     />
                   )


### PR DESCRIPTION
Addresses issues raised in https://github.com/bazel-contrib/bcr-ui/issues/161

Currently draft, will need some tweaking. I think some more examples of representative searches would be most helpful.

Some examples (WIP):
- `typescript` -> should include `rules_ts` in top results because it's in description
- `go` -> should include `rules_go` in top results
- `oci` -> should include `rules_img` in top results  because `oci` is in description (and rules_oci...this PR has both, live version only has rules_oci)
- `python` -> should include `aspect_rules_py` in top results because it's in description
- `tar` -> should have `rules_pkg` in top results

I see that BCR takes some inspiration from the the rust crates site. I feel like we could search results based on this page more rather than the homepage: https://crates.io/crates