### PR TITLE
fix: skip repos when metadata fetch fails

### DIFF
--- a/.github/workflows/fetch_repo_metadata.sh
+++ b/.github/workflows/fetch_repo_metadata.sh
@@ -38,7 +38,11 @@ SCRIPT_DIR=$(dirname "$0")
             continue
         fi
         
-        gh repo view --json description,licenseInfo,repositoryTopics,stargazerCount,isArchived,fundingLinks "$organdrepo" > $OUT/$module.github_metadata.json
+        if ! gh repo view --json description,licenseInfo,repositoryTopics,stargazerCount,isArchived,fundingLinks "$organdrepo" > $OUT/$module.github_metadata.json; then
+            echo "  Failed to fetch metadata for $organdrepo, skipping..."
+            rm -f "$OUT/$module.github_metadata.json"
+            continue
+        fi
     done
 )
 


### PR DESCRIPTION
## Summary
- keep the metadata workflow running when `gh repo view` fails for a module repository
- remove any partial metadata file before continuing to the next module

This prevents one missing or inaccessible repository (for example `mathematic-inc/rules_mjml`) from failing the full `fetch_repo_metadata` workflow used by the BCR trigger.

Fixes #245

## Validation
- `bash -n .github/workflows/fetch_repo_metadata.sh`
- `git diff --check`

Note: `shellcheck` is not installed in my local environment.
